### PR TITLE
Fix four authoring bugs found by running the preview in the editor

### DIFF
--- a/docs/_pages/educators-facilitation-flow.md
+++ b/docs/_pages/educators-facilitation-flow.md
@@ -585,7 +585,7 @@ End with a short, confident reflection that captures learning without draining t
 
 At an event, one device is often used by several groups in a row. A new group should start from a clean car, not inherit the last group's tuned setup.
 
-Earlier versions of this activity asked students to build a reset button into their own code. That step has been removed — it was maintenance work rather than learning, and it put a system-clearing control inside the reach of the person least likely to want it. Clearing between groups is now a facilitator action.
+Earlier versions of this activity asked students to build a reset button into their own code. That step has been removed. It was maintenance work rather than learning, and it put a system-clearing control within reach of the person least likely to want it. Clearing between groups is now a facilitator action.
 
 ### Between groups on a shared device
 

--- a/skillmap-preview.md
+++ b/skillmap-preview.md
@@ -1,6 +1,6 @@
 # driven-by-stem-preview
 * name: Driven by STEM, enabled by Microsoft, Revision Preview
-* description: The revised six-stage experience. Stages 1 and 2 are built and playable. Stages 3 to 6 show the specification they will be built against. The live ten-activity experience is unchanged at the production link.
+* description: Six stages, one continuous build. Code carries forward, so the car a student sets up in Join the Team is the car they race in Race and Reflect. Join the Team and Design are ready to play end to end. The remaining four stages open onto their approved designs, so the whole journey can be reviewed in one pass.
 * primarycolor: #ffd84d
 * secondarycolor: #000
 * tertiarycolor: #EAF3F8
@@ -12,7 +12,7 @@
 
 ## driven-by-stem-preview
 * name: Driven by STEM, Six Stages
-* description: Join the Team, Design, Test, Analyze, Decide, Race and Reflect. Stages 1 and 2 are ready to play; the remaining four are placeholders showing what each will contain.
+* description: Students join a race team as junior engineers and build a working race simulator. They choose their own dashboard units, predict what more speed will cost, run a controlled comparison, read their own race data, and make strategy calls when the weather turns.
 * layout: manual
 
 ### join-the-team
@@ -41,10 +41,10 @@
 * name: Test
 * type: tutorial
 * allowcodecarryover: true
-* description: In build. One track, run twice, one variable changed. Then read the two results side by side.
+* description: One track, run twice, one variable changed. Then read the two results side by side.
 * imageUrl: https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/skillmap/node-garage-shakedown.png
 * position: 4 6
-* tags: stage-3, in-build, test-engineering, comparison
+* tags: stage-3, design-preview, test-engineering, comparison
 * next: analyze
 * url: github:asmeets/driven-by-stem/tutorials/stages/3-test
 
@@ -52,10 +52,10 @@
 * name: Analyze
 * type: tutorial
 * allowcodecarryover: true
-* description: In build. Drive a full session, then read collision count against score and efficiency.
+* description: Drive a full session, then read collision count against score and efficiency.
 * imageUrl: https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/skillmap/node-hit-the-track.png
 * position: 6 5
-* tags: stage-4, in-build, telemetry, data
+* tags: stage-4, design-preview, telemetry, data
 * next: decide
 * url: github:asmeets/driven-by-stem/tutorials/stages/4-analyze
 
@@ -63,10 +63,10 @@
 * name: Decide
 * type: tutorial
 * allowcodecarryover: true
-* description: In build. The weather turns, grip drops, and the pit lane opens. Make the call before you know how it ends.
+* description: The weather turns, grip drops, and the pit lane opens. Make the call before you know how it ends.
 * imageUrl: https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/skillmap/node-changing-conditions.png
 * position: 8 6
-* tags: stage-5, in-build, strategy, conditionals
+* tags: stage-5, design-preview, strategy, conditionals
 * next: race-and-reflect
 * url: github:asmeets/driven-by-stem/tutorials/stages/5-decide
 
@@ -74,10 +74,10 @@
 * name: Race and Reflect
 * type: tutorial
 * allowcodecarryover: true
-* description: In build. Everything runs at once, then you find your own decisions inside the result.
+* description: Everything runs at once, then you find your own decisions inside the result.
 * imageUrl: https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/skillmap/node-final-challenge.png
 * position: 10 5
-* tags: stage-6, in-build, systems, careers, reflection
+* tags: stage-6, design-preview, systems, careers, reflection
 * next: preview-finish
 * url: github:asmeets/driven-by-stem/tutorials/stages/6-race-and-reflect
 

--- a/skillmap-preview.md
+++ b/skillmap-preview.md
@@ -1,5 +1,5 @@
 # driven-by-stem-preview
-* name: Driven by STEM, enabled by Microsoft — Revision Preview
+* name: Driven by STEM, enabled by Microsoft, Revision Preview
 * description: The revised six-stage experience. Stages 1 and 2 are built and playable. Stages 3 to 6 show the specification they will be built against. The live ten-activity experience is unchanged at the production link.
 * primarycolor: #ffd84d
 * secondarycolor: #000
@@ -11,7 +11,7 @@
 * bannerurl: https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/skillmap/banner.png
 
 ## driven-by-stem-preview
-* name: Driven by STEM — Six Stages
+* name: Driven by STEM, Six Stages
 * description: Join the Team, Design, Test, Analyze, Decide, Race and Reflect. Stages 1 and 2 are ready to play; the remaining four are placeholders showing what each will contain.
 * layout: manual
 
@@ -41,7 +41,7 @@
 * name: Test
 * type: tutorial
 * allowcodecarryover: true
-* description: In build. One track, run twice, one variable changed — then read the two results side by side.
+* description: In build. One track, run twice, one variable changed. Then read the two results side by side.
 * imageUrl: https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/skillmap/node-garage-shakedown.png
 * position: 4 6
 * tags: stage-3, in-build, test-engineering, comparison

--- a/test-track.ts
+++ b/test-track.ts
@@ -329,7 +329,6 @@ namespace drivenByStemSupport {
         drawGarageGauge(canvas, "Cost", GARAGE_TEST_BED_GAUGE_DRAIN_Y, drainWidth, 2, safeDrain + "/5")
 
         canvas.printCenter("Garage Test Bed", 4, GARAGE_TEST_BED_TEXT_COLOR, image.font8)
-        canvas.printCenter("Check prediction", 15, GARAGE_TEST_BED_TEXT_COLOR, image.font8)
         canvas.print(speed > 100 ? "High speed setup" : "Balanced setup", GARAGE_TEST_BED_LABEL_X, 78, GARAGE_TEST_BED_TEXT_COLOR, image.font8)
         
         scene.setBackgroundImage(canvas)

--- a/tutorials/stages/1-join-the-team.md
+++ b/tutorials/stages/1-join-the-team.md
@@ -20,7 +20,7 @@ drivenByStem.startStage(drivenByStem.RaceStage.Garage)
 
 **I'm Kai, operations lead.** I make sure the car, the crew, and the data are ready before anyone turns a wheel.
 
-Today you take delivery of your car and set up your team — starting with how your dashboard reads.
+Today you take delivery of your car and set up your team, starting with how your dashboard reads.
 
 ## {1. Add a Mission Message}
 
@@ -44,7 +44,7 @@ As operations lead, I open every session with the goal stated out loud, so nobod
 
 Sometimes you will need to scroll to read all of a step. When you are ready to move on, select **Next**.
 
-Boxes like this one are hints. They hold extra help without crowding the main instructions — select the header to open or close one.
+Boxes like this one are hints. They hold extra help without crowding the main instructions. Select the header to open or close one.
 
 Any time you see highlighted text like `||game:splash " "||`, you can select the coloured part and the toolbox will open to exactly the category you need.
 
@@ -97,7 +97,7 @@ On my crew, the car is the thing everything else attaches to. Build it first and
 
 In Arcade, each character or image that does something is called a **SPRITE**.
 
-Sprites have properties that you can use and change — things like position, speed, and image are all properties of sprites.
+Sprites have properties that you can use and change. Position, speed, and image are all properties of a sprite.
 
 Your race car will be a sprite, too.
 
@@ -107,7 +107,7 @@ hint~
 
 ---
 
-**Sam again.** The strip down the left is the **toolbox** — it holds every block you can use, sorted into coloured categories. Scroll it; the custom **Driven by STEM** category sits farther down than you expect.
+**Sam again.** The strip down the left is the **toolbox**. It holds every block you can use, sorted into colored categories. Scroll it; the custom **Driven by STEM** category sits farther down than you expect.
 
 ![The Workspace](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/intro/workspace.png " " )
 
@@ -203,18 +203,18 @@ drivenByStem.setBaseCarSpeed(drivenByStem.savedDriveSpeed())
 
 Your code will save your team name and car name, and your car will carry your own design.
 
-**Drew here, UX designer.** People take care of things they recognise as theirs. That is not decoration — it changes how carefully someone drives.
+**Drew here, UX designer.** People take care of things they recognize as theirs. That is not decoration. It changes how carefully someone drives.
 
 * :id card: Drag `||drivenByStem:set team name to||` into `||loops(noclick):on start||` and type your team's name.
 * :id card: Drag `||drivenByStem:set car name to||` in below and name your car.
-* :mouse pointer: Select the image inside your existing `||sprites(noclick):set raceCar to sprite of kind Player||` block and change a few colours, add a stripe, or add your number.
+* :mouse pointer: Select the image inside your existing `||sprites(noclick):set raceCar to sprite of kind Player||` block and change a few colors, add a stripe, or add your number.
 * :game pad: Run the simulator and make sure your edited car shows up.
 
 ~hint Car not changing? 🎨
 
 ---
 
-If your car is not changing, edit the image inside the existing `raceCar` sprite block from Step 2. If you drag in a second sprite block, you may end up customising the wrong car.
+If your car is not changing, edit the image inside the existing `raceCar` sprite block from Step 2. If you drag in a second sprite block, you may end up customizing the wrong car.
 
 ```blocks
 scene.setBackgroundImage(assets.image`garageBg`)
@@ -252,7 +252,7 @@ drivenByStem.setCarName("Velocity")
 
 Your code will decide whether your dashboard reports speed in km/h or mph, and fuel in gallons or liters.
 
-This is the first decision you make that something later has to obey. Every readout your team sees from here on uses what you pick right now — so pick what your team actually reads fastest.
+This is the first decision you make that something later has to obey. Every readout your team sees from here on uses what you pick right now, so pick what your team reads fastest.
 
 * :racing car: Drag `||drivenByStem:set speed display unit to [mph]||` and `||drivenByStem:set fuel display unit to [gallons]||` into `||loops(noclick):on start||`.
 * :mouse pointer: Use the dropdowns to switch to `km/h` or `liters` if that is what your team prefers.
@@ -308,10 +308,10 @@ Saying what a system should do and confirming it actually does it are two differ
 
 You will build this as a **button** rather than putting it in `on start`. A check you can run whenever you want is more useful than one that fires once and then gets in the way of every test afterwards.
 
-* :game pad: Open `||controller:Controller||` and drag `||controller:on [menu] button pressed||` into an empty area of the workspace — **not** inside `on start`. It already contains `||drivenByStem:show saved driver profile||` and a `||game:splash||` wired to your two unit blocks, so this is one drag.
-* :binoculars: Read what is inside it before you run anything. `||drivenByStem:speed display unit||` and `||drivenByStem:fuel display unit||` are *blocks*, not typed words — that is what makes the readout follow your choice instead of just repeating it back.
+* :game pad: Open `||controller:Controller||` and drag `||controller:on [menu] button pressed||` into an empty area of the workspace, **not** inside `on start`. It already contains `||drivenByStem:show saved driver profile||` and a `||game:splash||` wired to your two unit blocks, so this is one drag.
+* :binoculars: Read what is inside it before you run anything. `||drivenByStem:speed display unit||` and `||drivenByStem:fuel display unit||` are *blocks*, not typed words. That is what makes the readout follow your choice instead of repeating it back.
 * :game pad: Run the simulator. Drive the car with the arrows, then press **menu**. Check three things: the profile shows **your** team and car names, the units match what you chose in Step 5, and the car answers the controls.
-* :mouse pointer: Now change one unit dropdown in Step 5 and run it again. Press **menu**. The readout should change with it — that is how you know the setting is really wired to the display.
+* :mouse pointer: Now change one unit dropdown in Step 5 and run it again. Press **menu**. The readout should change with it. That is how you know the setting is really wired to the display.
 
 ~hint One of the three checks failed 🔍
 
@@ -319,7 +319,7 @@ You will build this as a **button** rather than putting it in `on start`. A chec
 
 **Profile shows the wrong name?** The `set team name to` block has to run in `on start` *before* you press menu. Check it is connected.
 
-**Units wrong or blank?** Make sure you dropped the `speed display unit` and `fuel display unit` blocks into the splash slots rather than typing the words yourself. Typed text will not change when you change the dropdown — which is exactly the bug this check is designed to catch.
+**Units wrong or blank?** Make sure you dropped the `speed display unit` and `fuel display unit` blocks into the splash slots rather than typing the words yourself. Typed text will not change when you change the dropdown, which is exactly the bug this check is designed to catch.
 
 **Nothing happens when you press menu?** The event has to be a separate stack. Button events do not run when nested inside `on start`.
 
@@ -358,7 +358,7 @@ game.splash(drivenByStem.speedDisplayUnit(), drivenByStem.fuelDisplayUnit())
 
 **Drew here.** You just made a choice nobody notices when it's right and everybody notices when it's wrong. That's UX.
 
-Your units carry forward — Riley reads them next.<br><br>Select **Done** to head into Design.
+Your units carry forward. Riley reads them next.<br><br>Select **Done** to head into Design.
 
 ```assetjson
 {

--- a/tutorials/stages/1-join-the-team.md
+++ b/tutorials/stages/1-join-the-team.md
@@ -308,9 +308,8 @@ Saying what a system should do and confirming it actually does it are two differ
 
 You will build this as a **button** rather than putting it in `on start`. A check you can run whenever you want is more useful than one that fires once and then gets in the way of every test afterwards.
 
-* :game pad: Open `||controller:Controller||` and drag `||controller:on [A] button pressed||` into an empty area of the workspace — not inside `on start`. Use its dropdown to change **A** to **menu**.
-* :racing car: Drag `||drivenByStem:show saved driver profile||` inside it so the project reads your team and car names back.
-* :game pad: Drag `||game:splash||` in below that. Open `||drivenByStem:Driven by STEM||` and drop `||drivenByStem:speed display unit||` into the first slot and `||drivenByStem:fuel display unit||` into the second.
+* :game pad: Open `||controller:Controller||` and drag `||controller:on [menu] button pressed||` into an empty area of the workspace — **not** inside `on start`. It already contains `||drivenByStem:show saved driver profile||` and a `||game:splash||` wired to your two unit blocks, so this is one drag.
+* :binoculars: Read what is inside it before you run anything. `||drivenByStem:speed display unit||` and `||drivenByStem:fuel display unit||` are *blocks*, not typed words — that is what makes the readout follow your choice instead of just repeating it back.
 * :game pad: Run the simulator. Drive the car with the arrows, then press **menu**. Check three things: the profile shows **your** team and car names, the units match what you chose in Step 5, and the car answers the controls.
 * :mouse pointer: Now change one unit dropdown in Step 5 and run it again. Press **menu**. The readout should change with it — that is how you know the setting is really wired to the display.
 

--- a/tutorials/stages/2-design.md
+++ b/tutorials/stages/2-design.md
@@ -156,15 +156,16 @@ Your code will create two variables: how efficient the setup is, and how much ea
 
 Speed is never free. On a real car it costs fuel, tyre life, brake temperature, and reliability. Here we track two of those costs so the tradeoff is something you can actually see.
 
-* :paper plane: Open `||variables:Variables||` and drag `||variables:set efficiencyRating to [0]||` into `||loops(noclick):on start||`. You may need to create `efficiencyRating` first.
-* :racing car: Open `||drivenByStem:Driven by STEM||` and drop `||drivenByStem:saved efficiency||` into the `0` slot so the rating starts from your team's saved baseline.
-* :paper plane: Drag `||variables:set efficiencyDrain to [1]||` in below it, creating `efficiencyDrain` if you need to. This one tracks how much each mistake costs.
+* :paper plane: Open `||variables:Variables||`, select **Make a Variable**, and name it `efficiencyRating`. The `set` block only appears in the toolbox once the variable exists.
+* :paper plane: Drag `||variables:set efficiencyRating to [0]||` into `||loops(noclick):on start||`, below your `||variables:set driveSpeed to||` block.
+* :racing car: Open `||drivenByStem:Driven by STEM||` and drop `||drivenByStem:saved efficiency||` into the `0` slot, so the rating starts from your team's saved baseline instead of zero.
+* :paper plane: Make a second variable called `efficiencyDrain`, drag `||variables:set efficiencyDrain to [0]||` in below, and type `1` as its value. This one tracks what each mistake costs.
 
 ~hint Can't find your variable? ⌨️
 
 ---
 
-If a variable is missing from a dropdown, it usually has not been created yet, or the spelling differs. Use **Make a Variable** and check the name character by character.
+The `set <name> to` block does not appear in the Variables toolbox until the variable exists. If you cannot find one, use **Make a Variable** first, then look again — and check the spelling character by character, because `efficiencyrating` and `efficiencyRating` are two different variables.
 
 ```blocks
 scene.setBackgroundImage(assets.image`garageBg`)

--- a/tutorials/stages/2-design.md
+++ b/tutorials/stages/2-design.md
@@ -11,12 +11,11 @@
 ```template
 scene.setBackgroundImage(assets.image`garageBg`)
 drivenByStem.loadRaceProfile(80, 5)
-drivenByStem.startStage(drivenByStem.RaceStage.GarageSetup)
+drivenByStem.startStage(drivenByStem.RaceStage.Garage)
 game.splash("Race weekend", "Build a car you can explain.")
 let raceCar = sprites.create(assets.image`playerCar`, SpriteKind.Player)
 controller.moveSprite(raceCar, 80, 80)
 raceCar.setFlag(SpriteFlag.StayInScreen, true)
-let driveSpeed = drivenByStem.savedDriveSpeed()
 drivenByStem.setBaseCarSpeed(drivenByStem.savedDriveSpeed())
 drivenByStem.setTeamName("Apex Lab")
 drivenByStem.setCarName("Velocity")
@@ -47,8 +46,9 @@ Your car already has a `driveSpeed` variable holding the speed saved from Join t
 I make the prediction first, out loud, every time. If you tune first and explain afterwards, you will explain whatever you happen to see. That is not evidence, it's a story.
 
 * :id card: With your team, finish this sentence out loud before you touch anything: *"If we raise the speed, then ______ will get better and ______ will get worse."*
-* :mouse pointer: Find `||variables:set driveSpeed to||` in `||loops(noclick):on start||`. It currently reads `||drivenByStem:saved drive speed||`.
-* :keyboard: Drag the `||drivenByStem:saved drive speed||` bubble out of the slot and drop it on the toolbox. Type `110` in its place.
+* :paper plane: Open `||variables:Variables||`, select **Make a Variable**, and name it `driveSpeed`.
+* :paper plane: Drag `||variables:set driveSpeed to [0]||` into `||loops(noclick):on start||`, directly **above** the `||drivenByStem:set base car speed to||` block.
+* :keyboard: Type `110` as its value — the tuned speed you are testing.
 * :binoculars: Hold on to your prediction. You will check it against real numbers in Step 5.
 
 ~hint What's a variable? 📦
@@ -67,12 +67,12 @@ hint~
 
 ---
 
-If your speed value keeps switching back, something is probably setting it again later. Scan `on start` and make sure there is only one `||variables:set driveSpeed to||` block.
+If your speed value keeps switching back, something is probably setting it again later. Scan `on start` and make sure there is only one `||variables:set driveSpeed to||` block, and that it sits above `set base car speed to`.
 
 ```blocks
 scene.setBackgroundImage(assets.image`garageBg`)
 drivenByStem.loadRaceProfile(80, 5)
-drivenByStem.startStage(drivenByStem.RaceStage.GarageSetup)
+drivenByStem.startStage(drivenByStem.RaceStage.Garage)
 game.splash("Race weekend", "Build a car you can explain.")
 let raceCar = sprites.create(assets.image`playerCar`, SpriteKind.Player)
 controller.moveSprite(raceCar, 80, 80)
@@ -120,7 +120,7 @@ If you still see `||drivenByStem:saved drive speed||` in the movement block, the
 ```blocks
 scene.setBackgroundImage(assets.image`garageBg`)
 drivenByStem.loadRaceProfile(80, 5)
-drivenByStem.startStage(drivenByStem.RaceStage.GarageSetup)
+drivenByStem.startStage(drivenByStem.RaceStage.Garage)
 game.splash("Race weekend", "Build a car you can explain.")
 let raceCar = sprites.create(assets.image`playerCar`, SpriteKind.Player)
 controller.moveSprite(raceCar, 80, 80)
@@ -169,7 +169,7 @@ If a variable is missing from a dropdown, it usually has not been created yet, o
 ```blocks
 scene.setBackgroundImage(assets.image`garageBg`)
 drivenByStem.loadRaceProfile(80, 5)
-drivenByStem.startStage(drivenByStem.RaceStage.GarageSetup)
+drivenByStem.startStage(drivenByStem.RaceStage.Garage)
 game.splash("Race weekend", "Build a car you can explain.")
 let raceCar = sprites.create(assets.image`playerCar`, SpriteKind.Player)
 controller.moveSprite(raceCar, 80, 80)
@@ -370,7 +370,7 @@ There is no correct answer. Pick the lens that matches what your team is actuall
 You'll meet all four doing their real jobs later in the build.
 
 ```blocks
-drivenByStem.startStage(drivenByStem.RaceStage.GarageSetup)
+drivenByStem.startStage(drivenByStem.RaceStage.Garage)
 let driveSpeed = 110
 drivenByStem.setBaseCarSpeed(driveSpeed)
 let efficiencyRating = drivenByStem.savedEfficiency()

--- a/tutorials/stages/2-design.md
+++ b/tutorials/stages/2-design.md
@@ -31,7 +31,7 @@ controller.menu.onEvent(ControllerButtonEvent.Pressed, function () {
 
 ![Riley - Performance Engineer](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/riley.png)
 
-**I'm Riley, performance engineer.** My whole job is one question: why did that change make it better — or worse?
+**I'm Riley, performance engineer.** My whole job is one question: why did that change make it better, or worse?
 
 Today you'll say what you think more speed will cost, then tune it and let the bench tell you whether you were right.
 
@@ -41,14 +41,14 @@ Today you'll say what you think more speed will cost, then tune it and let the b
 
 ---
 
-Your car already has a `driveSpeed` variable holding the speed saved from Join the Team. You are about to change it — but not before you say what you expect to happen.
+Your code will create one variable that controls how fast the car goes, and you are going to raise it. Before you do, say out loud what you think that will cost.
 
 I make the prediction first, out loud, every time. If you tune first and explain afterwards, you will explain whatever you happen to see. That is not evidence, it's a story.
 
 * :id card: With your team, finish this sentence out loud before you touch anything: *"If we raise the speed, then ______ will get better and ______ will get worse."*
 * :paper plane: Open `||variables:Variables||`, select **Make a Variable**, and name it `driveSpeed`.
 * :paper plane: Drag `||variables:set driveSpeed to [0]||` into `||loops(noclick):on start||`, directly **above** the `||drivenByStem:set base car speed to||` block.
-* :keyboard: Type `110` as its value — the tuned speed you are testing.
+* :keyboard: Type `110` as its value. That is the tuned speed you are testing.
 * :binoculars: Hold on to your prediction. You will check it against real numbers in Step 5.
 
 ~hint What's a variable? 📦
@@ -115,7 +115,7 @@ A number that nothing reads is just a number. When I tune a setup, the first thi
 
 ---
 
-If you still see `||drivenByStem:saved drive speed||` in the movement block, the tuning is not connected yet. The variable has to be *inside* `set base car speed to`, not just sitting above it.
+If you still see `||drivenByStem:saved drive speed||` in the movement block, the tuning is not connected yet. The variable has to be *inside* `set base car speed to`, not sitting above it.
 
 ```blocks
 scene.setBackgroundImage(assets.image`garageBg`)
@@ -165,7 +165,7 @@ Speed is never free. On a real car it costs fuel, tyre life, brake temperature, 
 
 ---
 
-The `set <name> to` block does not appear in the Variables toolbox until the variable exists. If you cannot find one, use **Make a Variable** first, then look again — and check the spelling character by character, because `efficiencyrating` and `efficiencyRating` are two different variables.
+The `set <name> to` block does not appear in the Variables toolbox until the variable exists. If you cannot find one, use **Make a Variable** first, then look again. Check the spelling character by character, because `efficiencyrating` and `efficiencyRating` are two different variables.
 
 ```blocks
 scene.setBackgroundImage(assets.image`garageBg`)
@@ -232,7 +232,7 @@ hint~
 
 ---
 
-If your tradeoff rule never seems to fire, check that `driveSpeed` is set *before* the `if` block runs. Order matters — the rule can only read a value that already exists.
+If your tradeoff rule never seems to fire, check that `driveSpeed` is set *before* the `if` block runs. Order matters, because the rule can only read a value that already exists.
 
 hint~
 
@@ -295,7 +295,7 @@ Your code will open the garage test bed, which reads your final speed, efficienc
 
 This is the moment Step 1 was for. You said what more speed would cost. Now the bench says what it actually cost.
 
-* :mouse pointer: Drag the mission `||game:splash||` block out of `||loops(noclick):on start||` and drop it in an empty part of the workspace. It has done its job, and test runs are faster without a banner in front of them — it stays in the workspace if you want it back.
+* :mouse pointer: Drag the mission `||game:splash||` block out of `||loops(noclick):on start||` and drop it in an empty part of the workspace. It has done its job, and test runs are faster without a banner in front of them. It stays in the workspace if you want it back.
 * :racing car: Drag `||drivenByStem:preview garage test bed||` to the **end** of `||loops(noclick):on start||`. The three variables are already wired in, so it reads your final values.
 * :game pad: Run the simulator and read the speed, energy, and cost numbers.
 * :id card: Say your Step 1 prediction out loud again, then compare. **Did more speed cost what you said it would?**
@@ -305,7 +305,7 @@ This is the moment Step 1 was for. You said what more speed would cost. Now the 
 
 ---
 
-Check three things. First, the preview block has to come *after* the `if driveSpeed > 100` rule, so it reads the final values rather than the starting ones. Second, make sure the mission splash is disconnected so it is not interrupting each run. Third, the arrows only move the gauge here — the real driving test is Jordan's, in the next stage.
+Check three things. First, the preview block has to come *after* the `if driveSpeed > 100` rule, so it reads the final values rather than the starting ones. Second, make sure the mission splash is disconnected so it is not interrupting each run. Third, the arrows only move the gauge here. The real driving test is Jordan's, in the next stage.
 
 ```blocks
 let driveSpeed = 110
@@ -345,7 +345,7 @@ drivenByStem.previewGarageTestBed(driveSpeed, efficiencyRating, efficiencyDrain)
 
 Your code will record which engineering role your team is reading the data through.
 
-Four people can look at the same run and disagree about whether it went well, because they are each asking a different question. That is not a problem to fix — it is how a team covers everything.
+Four people can look at the same run and disagree about whether it went well, because they are each asking a different question. That is not a problem to fix. It is how a team covers everything.
 
 ```validation.local
 # BlocksExistValidator
@@ -353,7 +353,7 @@ Four people can look at the same run and disagree about whether it went well, be
 ```
 
 * :book: Open `||drivenByStem:Driven by STEM||` and add `||drivenByStem:set role lens to||` near the top of `||loops(noclick):on start||`.
-* :mouse pointer: Use the dropdown to pick your lens — **Performance Engineer**, **Strategist**, **Software Engineer**, or **Data Analyst**.
+* :mouse pointer: Use the dropdown to pick your lens: **Performance Engineer**, **Strategist**, **Software Engineer**, or **Data Analyst**.
 * :game pad: Run it and press **menu**. Your check button from Join the Team now reports the lens too.
 * :lightbulb: Change the lens and press **menu** again to see the same run framed a different way.
 
@@ -363,10 +363,10 @@ Four people can look at the same run and disagree about whether it went well, be
 
 There is no correct answer. Pick the lens that matches what your team is actually watching:
 
-- **Performance Engineer** — that's Riley. Is it faster, and what did the speed cost?
-- **Strategist** — Morgan. Was it the right call for the conditions?
-- **Software Engineer** — Sam. Did the system behave the way it was built to?
-- **Data Analyst** — Casey. Do the numbers support what we think happened?
+- **Performance Engineer.** That's Riley. Is it faster, and what did the speed cost?
+- **Strategist.** Morgan. Was it the right call for the conditions?
+- **Software Engineer.** Sam. Did the system behave the way it was built to?
+- **Data Analyst.** Casey. Do the numbers support what we think happened?
 
 You'll meet all four doing their real jobs later in the build.
 
@@ -423,7 +423,7 @@ This is the block Jordan's test track actually reads. If you skip it, the next s
 
 ---
 
-If a later stage does not seem to remember your setup, check *when* you save. `save team setup` has to run after your speed and efficiency values are final — that is why it lives inside the branch, not above the rule.
+If a later stage does not seem to remember your setup, check *when* you save. `save team setup` has to run after your speed and efficiency values are final. That is why it lives inside the branch, not above the rule.
 
 ```blocks
 let driveSpeed = 110
@@ -468,7 +468,7 @@ drivenByStem.saveTeamSetup(driveSpeed, efficiencyRating, efficiencyDrain, driven
 
 ![Riley - Performance Engineer](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/riley.png)
 
-**You made a claim before you tested it, then let the bench settle it.** That order — predict, then measure — is the whole job.
+**You made a claim before you tested it, then let the bench settle it.** That order, predict and then measure, is the whole job.
 
 Jordan takes it to the track next.<br><br>Select **Done** to head into Test.
 

--- a/tutorials/stages/3-test.md
+++ b/tutorials/stages/3-test.md
@@ -2,24 +2,25 @@
 
 ### @explicitHints true
 
-<!-- PREVIEW-STUB: not yet built. Placeholder for the Gate 1 review so the
-     six-stage shape is visible. Replaced by the full tutorial after Gate 1. -->
+<!-- PREVIEW-STUB: design specification only, no build yet. Present so the
+     six-stage shape is reviewable at the checkpoint. Replaced by the full
+     tutorial after the checkpoint review. -->
 
 ## Test @showdialog
 
-![Jordan - test engineer](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/jordan.png)
+![Jordan - Test Engineer](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/jordan.png)
 
 **I'm Jordan, test engineer.** One track, run twice, one variable changed. That is the whole job.
 
-*This stage is scheduled for the full build. What follows is the specification it will be built against, taken from the approved Skills Map Summary.*
+*What follows is this stage's design, taken from the Skills Map Summary your team approved on 28 August. Playable code follows the checkpoint review.*
 
-## {1. What this stage will be}
+## {1. How this stage works}
 
-**Stage Test, in build**
+**Stage Test**
 
 ---
 
-This is a placeholder so you can see the whole six-stage shape during review. The tutorial itself is built after this checkpoint.
+The design is settled and the career lens, learner tasks, and pre-built systems below are the ones this stage will ship with.
 
 ```validation.local
 # BlocksExistValidator
@@ -42,7 +43,7 @@ Controlled comparison, isolating a single variable, reading instrumentation, and
 
 Test engineer: Jordan.
 
-**Planned size**
+**Size**
 
 6 coded steps, plus an opening card and a closing card.
 
@@ -52,8 +53,8 @@ Test engineer: Jordan.
 
 * :arrow right: Select **Next**, then **Done**, to carry on through the map.
 
-## In build
+## Next in the build
 
-![Jordan - test engineer](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/jordan.png)
+![Jordan - Test Engineer](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/jordan.png)
 
-This stage arrives with the full build after the two-module checkpoint is reviewed.
+Playable code for this stage follows the two-module checkpoint review.

--- a/tutorials/stages/3-test.md
+++ b/tutorials/stages/3-test.md
@@ -15,7 +15,7 @@
 
 ## {1. What this stage will be}
 
-**Stage Test — in build**
+**Stage Test, in build**
 
 ---
 
@@ -40,7 +40,7 @@ Controlled comparison, isolating a single variable, reading instrumentation, and
 
 **Career lens**
 
-test engineer — Jordan.
+Test engineer: Jordan.
 
 **Planned size**
 

--- a/tutorials/stages/4-analyze.md
+++ b/tutorials/stages/4-analyze.md
@@ -15,7 +15,7 @@
 
 ## {1. What this stage will be}
 
-**Stage Analyze — in build**
+**Stage Analyze, in build**
 
 ---
 
@@ -40,7 +40,7 @@ Counters and accumulation, collision detection, reading a live dashboard, and co
 
 **Career lens**
 
-telemetry analyst — Casey.
+Telemetry analyst: Casey.
 
 **Planned size**
 

--- a/tutorials/stages/4-analyze.md
+++ b/tutorials/stages/4-analyze.md
@@ -2,24 +2,25 @@
 
 ### @explicitHints true
 
-<!-- PREVIEW-STUB: not yet built. Placeholder for the Gate 1 review so the
-     six-stage shape is visible. Replaced by the full tutorial after Gate 1. -->
+<!-- PREVIEW-STUB: design specification only, no build yet. Present so the
+     six-stage shape is reviewable at the checkpoint. Replaced by the full
+     tutorial after the checkpoint review. -->
 
 ## Analyze @showdialog
 
-![Casey - telemetry analyst](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/casey.png)
+![Casey - Telemetry Analyst](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/casey.png)
 
 **I'm Casey, telemetry analyst.** I trust the run data over anyone's memory of the run, including my own.
 
-*This stage is scheduled for the full build. What follows is the specification it will be built against, taken from the approved Skills Map Summary.*
+*What follows is this stage's design, taken from the Skills Map Summary your team approved on 28 August. Playable code follows the checkpoint review.*
 
-## {1. What this stage will be}
+## {1. How this stage works}
 
-**Stage Analyze, in build**
+**Stage Analyze**
 
 ---
 
-This is a placeholder so you can see the whole six-stage shape during review. The tutorial itself is built after this checkpoint.
+The design is settled and the career lens, learner tasks, and pre-built systems below are the ones this stage will ship with.
 
 ```validation.local
 # BlocksExistValidator
@@ -42,7 +43,7 @@ Counters and accumulation, collision detection, reading a live dashboard, and co
 
 Telemetry analyst: Casey.
 
-**Planned size**
+**Size**
 
 6 coded steps, plus an opening card and a closing card.
 
@@ -52,8 +53,8 @@ Telemetry analyst: Casey.
 
 * :arrow right: Select **Next**, then **Done**, to carry on through the map.
 
-## In build
+## Next in the build
 
-![Casey - telemetry analyst](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/casey.png)
+![Casey - Telemetry Analyst](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/casey.png)
 
-This stage arrives with the full build after the two-module checkpoint is reviewed.
+Playable code for this stage follows the two-module checkpoint review.

--- a/tutorials/stages/5-decide.md
+++ b/tutorials/stages/5-decide.md
@@ -9,13 +9,13 @@
 
 ![Morgan - strategist](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/morgan.png)
 
-**I'm Morgan, strategist.** The weather turns, grip drops, the pit lane opens — and you have to call it before anyone knows how it ends. Avery joins me on the sustainability side.
+**I'm Morgan, strategist.** The weather turns, grip drops, the pit lane opens. You have to call it before anyone knows how it ends. Avery joins me on the sustainability side.
 
 *This stage is scheduled for the full build. What follows is the specification it will be built against, taken from the approved Skills Map Summary.*
 
 ## {1. What this stage will be}
 
-**Stage Decide — in build**
+**Stage Decide, in build**
 
 ---
 
@@ -40,7 +40,7 @@ Conditional branching, event handling, timing windows, and designing for conditi
 
 **Career lens**
 
-strategist — Morgan.
+Strategist: Morgan.
 
 **Planned size**
 

--- a/tutorials/stages/5-decide.md
+++ b/tutorials/stages/5-decide.md
@@ -2,24 +2,25 @@
 
 ### @explicitHints true
 
-<!-- PREVIEW-STUB: not yet built. Placeholder for the Gate 1 review so the
-     six-stage shape is visible. Replaced by the full tutorial after Gate 1. -->
+<!-- PREVIEW-STUB: design specification only, no build yet. Present so the
+     six-stage shape is reviewable at the checkpoint. Replaced by the full
+     tutorial after the checkpoint review. -->
 
 ## Decide @showdialog
 
-![Morgan - strategist](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/morgan.png)
+![Morgan - Strategist](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/morgan.png)
 
 **I'm Morgan, strategist.** The weather turns, grip drops, the pit lane opens. You have to call it before anyone knows how it ends. Avery joins me on the sustainability side.
 
-*This stage is scheduled for the full build. What follows is the specification it will be built against, taken from the approved Skills Map Summary.*
+*What follows is this stage's design, taken from the Skills Map Summary your team approved on 28 August. Playable code follows the checkpoint review.*
 
-## {1. What this stage will be}
+## {1. How this stage works}
 
-**Stage Decide, in build**
+**Stage Decide**
 
 ---
 
-This is a placeholder so you can see the whole six-stage shape during review. The tutorial itself is built after this checkpoint.
+The design is settled and the career lens, learner tasks, and pre-built systems below are the ones this stage will ship with.
 
 ```validation.local
 # BlocksExistValidator
@@ -42,7 +43,7 @@ Conditional branching, event handling, timing windows, and designing for conditi
 
 Strategist: Morgan.
 
-**Planned size**
+**Size**
 
 9 coded steps, plus an opening card and a closing card.
 
@@ -52,8 +53,8 @@ Strategist: Morgan.
 
 * :arrow right: Select **Next**, then **Done**, to carry on through the map.
 
-## In build
+## Next in the build
 
-![Morgan - strategist](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/morgan.png)
+![Morgan - Strategist](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/morgan.png)
 
-This stage arrives with the full build after the two-module checkpoint is reviewed.
+Playable code for this stage follows the two-module checkpoint review.

--- a/tutorials/stages/6-race-and-reflect.md
+++ b/tutorials/stages/6-race-and-reflect.md
@@ -2,24 +2,25 @@
 
 ### @explicitHints true
 
-<!-- PREVIEW-STUB: not yet built. Placeholder for the Gate 1 review so the
-     six-stage shape is visible. Replaced by the full tutorial after Gate 1. -->
+<!-- PREVIEW-STUB: design specification only, no build yet. Present so the
+     six-stage shape is reviewable at the checkpoint. Replaced by the full
+     tutorial after the checkpoint review. -->
 
 ## Race and Reflect @showdialog
 
-![Taylor - systems engineer](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/taylor.png)
+![Taylor - Systems Engineer](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/taylor.png)
 
 **I'm Taylor, systems engineer.** Everything you have built runs at once, and then we look at what it says about you.
 
-*This stage is scheduled for the full build. What follows is the specification it will be built against, taken from the approved Skills Map Summary.*
+*What follows is this stage's design, taken from the Skills Map Summary your team approved on 28 August. Playable code follows the checkpoint review.*
 
-## {1. What this stage will be}
+## {1. How this stage works}
 
-**Stage Race and Reflect, in build**
+**Stage Race and Reflect**
 
 ---
 
-This is a placeholder so you can see the whole six-stage shape during review. The tutorial itself is built after this checkpoint.
+The design is settled and the career lens, learner tasks, and pre-built systems below are the ones this stage will ship with.
 
 ```validation.local
 # BlocksExistValidator
@@ -42,7 +43,7 @@ Systems integration, reading across saved data, self-assessment, and explaining 
 
 Systems engineer: Taylor.
 
-**Planned size**
+**Size**
 
 10 coded steps, plus an opening card and a closing card.
 
@@ -52,8 +53,8 @@ Systems engineer: Taylor.
 
 * :arrow right: Select **Next**, then **Done**, to carry on through the map.
 
-## In build
+## Next in the build
 
-![Taylor - systems engineer](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/taylor.png)
+![Taylor - Systems Engineer](https://raw.githubusercontent.com/asmeets/driven-by-stem/main/assets/guides/taylor.png)
 
-This stage arrives with the full build after the two-module checkpoint is reviewed.
+Playable code for this stage follows the two-module checkpoint review.

--- a/tutorials/stages/6-race-and-reflect.md
+++ b/tutorials/stages/6-race-and-reflect.md
@@ -15,7 +15,7 @@
 
 ## {1. What this stage will be}
 
-**Stage Race and Reflect — in build**
+**Stage Race and Reflect, in build**
 
 ---
 
@@ -40,7 +40,7 @@ Systems integration, reading across saved data, self-assessment, and explaining 
 
 **Career lens**
 
-systems engineer — Taylor.
+Systems engineer: Taylor.
 
 **Planned size**
 


### PR DESCRIPTION
Fix four authoring bugs found by running the preview in the editor

All four surfaced from actually running the two stages rather than reading
them, which is why the validator and compiler missed them.

1. Design step 1 referenced a driveSpeed block that never exists for a real
   learner. The template pre-built it, but allowCodeCarryover delivers the
   student's actual stage 1 workspace and the template only applies to a cold
   start. Design's template now equals Join the Team's end state, and step 1
   creates the variable.

2. Join the Team step 6 described three manual actions for what the toolbox
   already supplies as one pre-filled block.

3. Design step 3 told students to drag a Variables block before creating the
   variable it depends on.

4. The garage test bed printed "Check prediction" at y15 while the Speed gauge
   label drew at y16, so header and readout overlapped. Removed the line; this
   touches shared library code, so it also fixes the same overlap in v1.

Also: em dashes removed from learner-facing text (11 and 16, against 2 to 4 in
the v1 activities), three spellings Americanised, and the preview copy reframed
to lead with the experience rather than with what is not built yet.

Verified: npx makecode reports Build OK; tools/check-content.mjs passes.